### PR TITLE
Ruby 3.1.6 deployment tweaks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,4 +333,4 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0)
 
 BUNDLED WITH
-   2.2.33
+   2.3.27

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,6 +37,15 @@ namespace :ndr_dev_support do
   end
 end
 
+desc 'ensure additional configuration for CentOS deployments'
+task :centos_deployment_specifics do
+  # We'd like to do the following, but scl incorrectly handles double quotes in passed commands:
+  # set :default_shell, 'scl enable devtoolset-9 -- sh'
+  set :default_shell, <<~CMD.chomp
+    sh -c 'scl_run() { echo "$@" | scl enable devtoolset-9 -; }; scl_run "$@"'
+  CMD
+end
+
 namespace :bundle do
   desc 'Ensure bundler is properly configured'
   task :configure do
@@ -56,4 +65,8 @@ TARGETS = [
 
 TARGETS.each do |env, name, app, port, app_user, is_web_server|
   add_target(env, name, app, port, app_user, is_web_server)
+end
+
+%i[pseudo_live].each do |name|
+  after name, 'centos_deployment_specifics'
 end


### PR DESCRIPTION
Tweaks to support Ruby 3.1.6 application deployment to CentOS 7 targets.